### PR TITLE
Prevent impersonating an admin

### DIFF
--- a/src/Access/UserPolicy.php
+++ b/src/Access/UserPolicy.php
@@ -11,6 +11,8 @@ class UserPolicy extends AbstractPolicy
 
     public function flagrowCanImpersonate(User $actor, User $user)
     {
-        return $actor->can('flagrow-impersonate.login') && $actor->id !== $user->id && (!$user->isAdmin() || $actor->isAdmin() && $user->isAdmin());
+        return $actor->can('flagrow-impersonate.login') &&
+            $actor->id !== $user->id &&
+            (!$user->isAdmin() || $actor->isAdmin());
     }
 }

--- a/src/Access/UserPolicy.php
+++ b/src/Access/UserPolicy.php
@@ -11,6 +11,6 @@ class UserPolicy extends AbstractPolicy
 
     public function flagrowCanImpersonate(User $actor, User $user)
     {
-        return $actor->can('flagrow-impersonate.login') && $actor->id !== $user->id;
+        return $actor->can('flagrow-impersonate.login') && $actor->id !== $user->id && (!$user->isAdmin() || $actor->isAdmin() && $user->isAdmin());
     }
 }


### PR DESCRIPTION
This change prevents a non admin user with Impersonate permission from being able to switch to an admin user, and therefore gaining extra permissions.

Tested on the giffgaff community