### PR TITLE
feat: optional flarum/audit integration

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -6,7 +6,7 @@ jobs:
   run:
     uses: flarum/framework/.github/workflows/REUSABLE_backend.yml@2.x
     with:
-      enable_backend_testing: false
+      enable_backend_testing: true
       enable_phpstan: true
 
       backend_directory: .

--- a/composer.json
+++ b/composer.json
@@ -69,15 +69,29 @@
             "FoF\\Impersonate\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "FoF\\Impersonate\\Tests\\": "tests/"
+        }
+    },
     "require-dev": {
+        "flarum/audit": "*",
         "flarum/testing": "^2.0.0",
         "flarum/phpstan": "^2.0.0"
     },
     "scripts": {
+        "test": [
+            "@test:integration"
+        ],
+        "test:integration": "phpunit -c tests/phpunit.integration.xml",
+        "test:setup": "@php tests/integration/setup.php",
         "analyse:phpstan": "phpstan analyse",
         "clear-cache:phpstan": "phpstan clear-result-cache"
     },
     "scripts-descriptions": {
+        "test": "Runs all tests.",
+        "test:integration": "Runs all integration tests.",
+        "test:setup": "Sets up a database for use with integration tests. Execute this only once.",
         "analyse:phpstan": "Run static analysis"
     },
     "minimum-stability": "beta",

--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         }
     },
     "require-dev": {
-        "flarum/audit": "*",
+        "flarum/audit": "2.x-dev",
         "flarum/testing": "^2.0.0",
         "flarum/phpstan": "^2.0.0"
     },

--- a/extend.php
+++ b/extend.php
@@ -14,6 +14,7 @@ namespace FoF\Impersonate;
 use Flarum\Api\Resource;
 use Flarum\Extend;
 use Flarum\User\User;
+use FoF\Impersonate\Events\Impersonated;
 
 return [
     (new Extend\Frontend('forum'))
@@ -32,4 +33,14 @@ return [
 
     (new Extend\Policy())
         ->modelPolicy(User::class, Access\UserPolicy::class),
+
+    (new Extend\Conditional())
+        ->whenExtensionEnabled('flarum-audit', fn () => [
+            (new \Flarum\Audit\Extend\Audit())
+                ->group('fof-impersonate')
+                ->listen(Impersonated::class, 'user.impersonated', fn ($e) => [
+                    'user_id' => $e->user->id,
+                    'reason'  => $e->switchReason ?: null,
+                ]),
+        ]),
 ];

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -16,3 +16,12 @@ fof-impersonate:
             impersonate_username: Login as {username}
         user_controls:
             impersonate_button: Login as user
+
+# Labels for the audit log entries this extension produces, rendered by the (optional)
+# flarum/audit browser. Defined under the flarum-audit namespace so the audit frontend
+# resolves them, but shipped here so they travel with the extension that owns the actions.
+flarum-audit:
+    lib:
+        browser:
+            user:
+                impersonated: Impersonated {username}

--- a/tests/integration/AuditTest.php
+++ b/tests/integration/AuditTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of fof/impersonate.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Impersonate\Tests\integration;
+
+use Flarum\Audit\AuditLog;
+use Flarum\Audit\AuditLogger;
+use Flarum\Extend\Csrf;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+
+class AuditTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Lifecycle events fired outside the test transaction shouldn't create stray entries.
+        AuditLogger::$testMode = true;
+
+        $this->extension('flarum-audit', 'fof-impersonate');
+
+        $this->extend((new Csrf())->exemptRoute('login'));
+
+        $this->prepareDatabase([
+            'audit_log' => [],
+            User::class => [
+                [
+                    'id'       => 3,
+                    'username' => 'user3',
+                    'email'    => 'user3@example.com',
+                ],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function impersonate()
+    {
+        $adminSession = $this->send($this->request('POST', '/login', [
+            'json' => [
+                'identification' => 'admin',
+                'password'       => 'password',
+            ],
+        ]));
+
+        // We can't use authenticateAs because Impersonate only works with sessions and not access tokens
+        $response = $this->send($this->request('POST', '/api/impersonate', [
+            'cookiesFrom' => $adminSession,
+            'json'        => [
+                'data' => [
+                    'attributes' => [
+                        'userId' => 3,
+                        'reason' => 'because', // Currently not optional, it would result in undefined index if not included
+                    ],
+                ],
+            ],
+        ])->withAddedHeader('X-CSRF-Token', $adminSession->getHeaderLine('X-CSRF-Token')));
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $log = AuditLog::query()->where('action', 'user.impersonated')->first();
+        $this->assertNotNull($log);
+        $this->assertEquals(1, $log->actor_id);
+        $this->assertEquals([
+            'user_id' => 3,
+            'reason'  => 'because',
+        ], $log->payload);
+    }
+}

--- a/tests/integration/setup.php
+++ b/tests/integration/setup.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of fof/impersonate.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Flarum\Testing\integration\Setup\SetupScript;
+
+require __DIR__.'/../../vendor/autoload.php';
+
+$setup = new SetupScript();
+
+$setup->run();

--- a/tests/phpunit.integration.xml
+++ b/tests/phpunit.integration.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../vendor/phpunit/phpunit/phpunit.xsd"
+    backupGlobals="false"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
+    colors="true"
+    processIsolation="true"
+    stopOnFailure="false"
+>
+    <source>
+        <include>
+            <directory suffix=".php">../src/</directory>
+        </include>
+    </source>
+    <testsuites>
+        <testsuite name="Flarum Integration Tests">
+            <directory suffix="Test.php">./integration</directory>
+            <exclude>./integration/tmp</exclude>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
Adds an optional `flarum/audit` integration, moved out of `flarum/audit` where it was previously bundled. Mirrors how `flarum/suspend` ships its own audit integration: a `Conditional` on `flarum-audit` using the public `Flarum\Audit\Extend\Audit` extender, the log labels shipped under the `flarum-audit.lib.browser.*` locale namespace, and an `AuditTest` covering it.

`flarum/audit` is added to `require-dev` only — at runtime it is an optional dependency (the integration is a no-op unless flarum-audit is enabled).

Companion to flarum/framework#4807, which removes this integration from `flarum/audit`. To avoid duplicate logging, these should be released together.

> This repo had no integration test suite yet, so minimal test infrastructure (phpunit config, `setup.php`, `autoload-dev`, composer `test` scripts) was scaffolded to host the `AuditTest`.