### PR TITLE
[2.x] feat: return to original account after impersonation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 js/node_modules
 vendor/
 composer.lock
-js/dist
+.phpunit.cache

--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 
 [![MIT license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/FriendsOfFlarum/impersonate/blob/master/LICENSE.md) [![Latest Stable Version](https://img.shields.io/packagist/v/fof/impersonate.svg)](https://packagist.org/packages/fof/impersonate) [![Total Downloads](https://img.shields.io/packagist/dt/fof/impersonate.svg)](https://packagist.org/packages/fof/impersonate) [![OpenCollective](https://img.shields.io/badge/opencollective-fof-blue.svg)](https://opencollective.com/fof/donate)
 
-This extension adds a "Log in as user" button on user profiles for administrators and others who are granted the permission.
+This extension adds a "Log in as user" button on user profiles for administrators and others who are granted the permission — and a way back: while impersonating, a notice is shown with a **Return to {username}** button that switches you back to your own account.
+
+## Features
+
+- **Impersonate users** from their user profile (moderation controls) or from the admin panel's user list.
+- **Return to your own account** without logging out: a persistent notice (and an entry in the user menu) offers "Return to {username}" for the whole impersonation session. If you logged in with "remember me", that is restored when you return.
+- **Require a reason** (optional setting): impersonation can require a reason, which is recorded in the audit log ([flarum/audit](https://github.com/flarum/audit)) and/or as moderator notes on both accounts ([fof/moderator-notes](https://github.com/FriendsOfFlarum/moderator-notes)), whichever is enabled.
+- **Audit logging**: with flarum/audit enabled, both starting and ending an impersonation are written to the audit log.
+- **No activity traces**: browsing as an impersonated user does not update their "last seen" time and never shows them as online. Their own devices are unaffected.
 
 ## Installation
 
@@ -24,7 +32,22 @@ php flarum cache:clear
 
 You can configure which groups can impersonate users by going to *Permissions > Login as other users*.
 Use with caution, as anybody with that permission can easily access the private data of every user on the forum.
-**non-admins cannot impersonate an admin account, for security reasons.**
+
+The *require a reason* setting appears once flarum/audit or fof/moderator-notes is enabled, since one of them is needed to record it.
+
+## Security model
+
+- **Non-admins cannot impersonate an admin account**, and nobody can impersonate themselves.
+- Permissions are checked against your **real current identity**: an impersonated session never inherits the impersonator's ability to impersonate.
+- Returning is bound to the session and to the exact account that was impersonated. It stops working when you log out, when the session expires (one hour of inactivity), or after logging into a different account — from then on, only credentials get you back in.
+- The impersonated session never carries a "remember me" cookie, so an idle browser cannot silently re-elevate itself.
+
+## For developers
+
+Two events are dispatched, which other extensions can listen to:
+
+- `FoF\Impersonate\Events\Impersonated` — when impersonation starts (`$actor`, `$user`, `$switchReason`).
+- `FoF\Impersonate\Events\ImpersonationEnded` — when the impersonator returns (`$user`, `$originalUser`).
 
 ## Links
 

--- a/composer.json
+++ b/composer.json
@@ -75,9 +75,10 @@
         }
     },
     "require-dev": {
-        "flarum/audit": "2.x-dev",
+        "flarum/audit": "^2.0.0",
         "flarum/testing": "^2.0.0",
-        "flarum/phpstan": "^2.0.0"
+        "flarum/phpstan": "^2.0.0",
+        "fof/moderator-notes": "^2.0.0-beta.4"
     },
     "scripts": {
         "test": [

--- a/extend.php
+++ b/extend.php
@@ -15,6 +15,7 @@ use Flarum\Api\Resource;
 use Flarum\Extend;
 use Flarum\User\User;
 use FoF\Impersonate\Events\Impersonated;
+use FoF\Impersonate\Events\ImpersonationEnded;
 
 return [
     (new Extend\Frontend('forum'))
@@ -23,13 +24,32 @@ return [
     (new Extend\Frontend('admin'))
         ->js(__DIR__.'/js/dist/admin.js'),
 
+    (new Extend\Frontend('common'))
+        ->jsDirectory(__DIR__.'/js/dist/common'),
+
     new Extend\Locales(__DIR__.'/resources/locale'),
 
+    (new Extend\ServiceProvider())
+        ->register(ImpersonateServiceProvider::class),
+
+    (new Extend\Middleware('forum'))
+        ->insertBefore(\Flarum\Http\Middleware\AuthenticateWithSession::class, Middleware\DetectImpersonation::class),
+
+    (new Extend\Middleware('admin'))
+        ->insertBefore(\Flarum\Http\Middleware\AuthenticateWithSession::class, Middleware\DetectImpersonation::class),
+
+    (new Extend\Middleware('api'))
+        ->insertBefore(\Flarum\Http\Middleware\AuthenticateWithSession::class, Middleware\DetectImpersonation::class),
+
     (new Extend\Routes('api'))
-        ->post('/impersonate', 'fof.impersonate.api.login', Controllers\LoginController::class),
+        ->post('/impersonate', 'fof.impersonate.api.login', Controllers\LoginController::class)
+        ->post('/impersonate/return', 'fof.impersonate.api.return', Controllers\ReturnController::class),
 
     (new Extend\ApiResource(Resource\UserResource::class))
         ->fields(Api\UserResourceFields::class),
+
+    (new Extend\ApiResource(Resource\ForumResource::class))
+        ->fields(Api\ForumResourceFields::class),
 
     (new Extend\Policy())
         ->modelPolicy(User::class, Access\UserPolicy::class),
@@ -41,6 +61,9 @@ return [
                 ->listen(Impersonated::class, 'user.impersonated', fn ($e) => [
                     'user_id' => $e->user->id,
                     'reason'  => $e->switchReason ?: null,
+                ])
+                ->listen(ImpersonationEnded::class, 'user.impersonation_ended', fn ($e) => [
+                    'user_id' => $e->originalUser->id,
                 ]),
         ]),
 ];

--- a/js/src/admin/extend.ts
+++ b/js/src/admin/extend.ts
@@ -4,12 +4,13 @@ import { default as commonExtend } from '../common/extend';
 
 const settings = [];
 
-if (app.initializers.has('fof-moderator-notes')) {
+if ('fof-moderator-notes' in flarum.extensions || 'flarum-audit' in flarum.extensions) {
   settings.push(
     new Extend.Admin().setting(() => ({
       setting: 'fof-impersonate.require_reason',
       type: 'boolean',
       label: app.translator.trans('fof-impersonate.admin.settings.require_reason'),
+      help: app.translator.trans('fof-impersonate.admin.settings.require_reason_help'),
     }))
   );
 }

--- a/js/src/common/components/ImpersonateModal.tsx
+++ b/js/src/common/components/ImpersonateModal.tsx
@@ -29,7 +29,7 @@ export default class ImpersonateModal extends FormModal<ImpersonateModalAttrs> {
     this.user = this.attrs.user;
     this.reason = Stream('');
     this.loading = false;
-    this.reasonEnabled = app.initializers.has('fof-moderator-notes');
+    this.reasonEnabled = 'fof-moderator-notes' in flarum.extensions || 'flarum-audit' in flarum.extensions;
     this.reasonRequired = this.user.impersonateReasonRequired();
   }
 

--- a/js/src/common/components/LoginAsUserButton.tsx
+++ b/js/src/common/components/LoginAsUserButton.tsx
@@ -2,7 +2,6 @@ import app from 'flarum/common/app';
 import Button from 'flarum/common/components/Button';
 import type { IButtonAttrs } from 'flarum/common/components/Button';
 import type User from 'flarum/common/models/User';
-import ImpersonateModal from './ImpersonateModal';
 
 export interface ILoginAsUserButtonAttrs extends IButtonAttrs {
   user: User;
@@ -20,7 +19,7 @@ export default class LoginAsUserButton extends Button<ILoginAsUserButtonAttrs> {
 
   loginAsUser(): void {
     const { user, redirectTo } = this.attrs;
-    app.modal.show(ImpersonateModal, {
+    app.modal.show(() => import('./ImpersonateModal'), {
       callback: () => {
         redirectTo ? (window.location.href = redirectTo) : window.location.reload();
       },

--- a/js/src/forum/components/ReturnToUserButton.tsx
+++ b/js/src/forum/components/ReturnToUserButton.tsx
@@ -1,0 +1,33 @@
+import app from 'flarum/forum/app';
+import Button from 'flarum/common/components/Button';
+import type { IButtonAttrs } from 'flarum/common/components/Button';
+
+export default class ReturnToUserButton extends Button<IButtonAttrs> {
+  loading: boolean = false;
+
+  view() {
+    return (
+      <Button {...this.attrs} icon="fas fa-undo" loading={this.loading} onclick={this.returnToOriginalUser.bind(this)}>
+        {app.translator.trans('fof-impersonate.forum.return.button', {
+          username: app.forum.attribute<string>('fofImpersonateOriginalUsername'),
+        })}
+      </Button>
+    );
+  }
+
+  returnToOriginalUser(): void {
+    this.loading = true;
+    m.redraw();
+
+    app
+      .request({
+        method: 'POST',
+        url: `${app.forum.attribute('apiUrl')}/impersonate/return`,
+      })
+      .then(() => window.location.reload())
+      .catch(() => {
+        this.loading = false;
+        m.redraw();
+      });
+  }
+}

--- a/js/src/forum/index.tsx
+++ b/js/src/forum/index.tsx
@@ -1,7 +1,15 @@
 import { extend } from 'flarum/common/extend';
 import app from 'flarum/forum/app';
 import UserControls from 'flarum/forum/utils/UserControls';
+import Notices from 'flarum/forum/components/Notices';
+import SessionDropdown from 'flarum/forum/components/SessionDropdown';
+import Alert from 'flarum/common/components/Alert';
+import username from 'flarum/common/helpers/username';
 import LoginAsUserButton from '../common/components/LoginAsUserButton';
+import ReturnToUserButton from './components/ReturnToUserButton';
+
+import type ItemList from 'flarum/common/utils/ItemList';
+import type Mithril from 'mithril';
 
 export { default as extend } from './extend';
 
@@ -9,6 +17,29 @@ app.initializers.add('fof-impersonate', () => {
   extend(UserControls, 'moderationControls', (items, user) => {
     if (user.canFoFImpersonate()) {
       items.add('fof-impersonate-login', <LoginAsUserButton user={user} />);
+    }
+  });
+
+  extend(Notices.prototype, 'items', function (items: ItemList<Mithril.Children>) {
+    if (app.forum.attribute('fofImpersonateOriginalUsername') && app.session.user) {
+      items.add(
+        'fof-impersonate',
+        <Alert
+          dismissible={false}
+          className="Alert--fofImpersonate"
+          containerClassName="container"
+          controls={[<ReturnToUserButton className="Button Button--link" />]}
+        >
+          {app.translator.trans('fof-impersonate.forum.notice.message', { username: <strong>{username(app.session.user)}</strong> })}
+        </Alert>,
+        110
+      );
+    }
+  });
+
+  extend(SessionDropdown.prototype, 'items', function (items: ItemList<Mithril.Children>) {
+    if (app.forum.attribute('fofImpersonateOriginalUsername')) {
+      items.add('fof-impersonate-return', <ReturnToUserButton />, -95);
     }
   });
 });

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -5,17 +5,24 @@ fof-impersonate:
         settings:
             title: FoF Impersonate
             require_reason: Require a reason to be entered before proceeding to impersonate another user.
-            no_settings_available: No settings are currently available. Try installing fof/moderator-notes
+            require_reason_help: The reason is recorded in the audit log (flarum/audit) and/or as moderator notes on both accounts (fof/moderator-notes), whichever is enabled.
+            no_settings_available: No settings are currently available. Try installing fof/moderator-notes or flarum/audit
 
     lib:
         modal:
             title: Login as another user
-            label: With great power comes great responsibility. By continuing, you will become {username} until you log out.
+            label: With great power comes great responsibility. By continuing, you will become {username} until you switch back.
             placeholder_optional: (Optional) Provide your reason for switching to this user
             placeholder_required: You must provide your reason for switching to this user before proceeding
             impersonate_username: Login as {username}
         user_controls:
             impersonate_button: Login as user
+
+    forum:
+        notice:
+            message: You are currently impersonating {username}.
+        return:
+            button: Return to {username}
 
 # Labels for the audit log entries this extension produces, rendered by the (optional)
 # flarum/audit browser. Defined under the flarum-audit namespace so the audit frontend
@@ -25,3 +32,4 @@ flarum-audit:
         browser:
             user:
                 impersonated: Impersonated {username}
+                impersonation_ended: Returned to {username}

--- a/src/Api/ForumResourceFields.php
+++ b/src/Api/ForumResourceFields.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of fof/impersonate.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Impersonate\Api;
+
+use Flarum\Api\Context;
+use Flarum\Api\Schema;
+use Flarum\User\User;
+use FoF\Impersonate\Impersonation;
+use Illuminate\Contracts\Session\Session;
+
+class ForumResourceFields
+{
+    public function __invoke(): array
+    {
+        return [
+            Schema\Str::make('fofImpersonateOriginalUsername')
+                ->visible(fn ($model, Context $context) => $this->originalUser($context) !== null)
+                ->get(fn ($model, Context $context) => $this->originalUser($context)?->username),
+        ];
+    }
+
+    protected function originalUser(Context $context): ?User
+    {
+        /**
+         * @var Session|null $session
+         */
+        $session = $context->request->getAttribute('session');
+
+        $originalUserId = $session?->get(Impersonation::ORIGINAL_USER_SESSION_KEY);
+
+        $actor = $context->getActor();
+
+        if (!$originalUserId || $actor->isGuest()) {
+            return null;
+        }
+
+        // Mirrors the return endpoint: after a credentialed login into a different
+        // account the markers are stale, so don't advertise a return path that
+        // would be denied.
+        if ($actor->id !== (int) $session->get(Impersonation::IMPERSONATED_USER_SESSION_KEY)) {
+            return null;
+        }
+
+        return User::query()->find($originalUserId);
+    }
+}

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -13,6 +13,8 @@ namespace FoF\Impersonate\Controllers;
 
 use Flarum\Extension\ExtensionManager;
 use Flarum\Foundation\ValidationException;
+use Flarum\Http\AccessToken;
+use Flarum\Http\RememberAccessToken;
 use Flarum\Http\Rememberer;
 use Flarum\Http\RequestUtil;
 use Flarum\Http\SessionAccessToken;
@@ -20,6 +22,7 @@ use Flarum\Http\SessionAuthenticator;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
 use FoF\Impersonate\Events\Impersonated;
+use FoF\Impersonate\Impersonation;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Events\Dispatcher;
 use Laminas\Diactoros\Response\JsonResponse;
@@ -60,9 +63,9 @@ class LoginController implements RequestHandlerInterface
         $requestData = $requestBody['data']['attributes'];
 
         $id = $requestData['userId'];
-        $reason = $requestData['reason'];
+        $reason = $requestData['reason'] ?? '';
 
-        if ($this->extensions->isEnabled('fof-moderator-notes') && (bool) $this->settings->get('fof-impersonate.require_reason') && empty($reason)) {
+        if ($this->reasonSupported() && (bool) $this->settings->get('fof-impersonate.require_reason') && empty($reason)) {
             throw new ValidationException([
                 'error' => $this->translator->trans('fof-impersonate.forum.modal.placeholder_required'),
             ]);
@@ -79,7 +82,32 @@ class LoginController implements RequestHandlerInterface
          * @var Session $session
          */
         $session = $request->getAttribute('session');
+
+        // logIn() replaces the session's token without deleting it. Capture it so it
+        // can be removed instead of lingering in the database, and so a remember
+        // login can be restored with a fresh token on return.
+        $previousTokenId = $session->get('access_token');
+        $previousToken = $previousTokenId ? AccessToken::findValid($previousTokenId) : null;
+
         $this->authenticator->logIn($session, SessionAccessToken::generate($user->id));
+
+        // Session attributes survive logIn()'s regeneration, so the markers set here
+        // (or by an earlier impersonation in a chain) persist until logout or return.
+        if ((int) $session->get(Impersonation::ORIGINAL_USER_SESSION_KEY) === $user->id) {
+            // Impersonated their way back to the account that started the chain.
+            $session->forget(Impersonation::ORIGINAL_USER_SESSION_KEY);
+            $session->forget(Impersonation::IMPERSONATED_USER_SESSION_KEY);
+            $session->forget(Impersonation::ORIGINAL_REMEMBER_SESSION_KEY);
+        } else {
+            if (!$session->has(Impersonation::ORIGINAL_USER_SESSION_KEY)) {
+                $session->put(Impersonation::ORIGINAL_USER_SESSION_KEY, $actor->id);
+                $session->put(Impersonation::ORIGINAL_REMEMBER_SESSION_KEY, $previousToken instanceof RememberAccessToken);
+            }
+
+            $session->put(Impersonation::IMPERSONATED_USER_SESSION_KEY, $user->id);
+        }
+
+        $previousToken?->delete();
 
         $this->bus->dispatch(new Impersonated($actor, $user, $reason));
 
@@ -93,5 +121,14 @@ class LoginController implements RequestHandlerInterface
                 ],
             ]
         ));
+    }
+
+    /**
+     * A reason can only be required when an extension that records it is enabled:
+     * fof/moderator-notes attaches it to the user, flarum/audit stores it in the log.
+     */
+    protected function reasonSupported(): bool
+    {
+        return $this->extensions->isEnabled('fof-moderator-notes') || $this->extensions->isEnabled('flarum-audit');
     }
 }

--- a/src/Controllers/ReturnController.php
+++ b/src/Controllers/ReturnController.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of fof/impersonate.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Impersonate\Controllers;
+
+use Flarum\Http\AccessToken;
+use Flarum\Http\RememberAccessToken;
+use Flarum\Http\Rememberer;
+use Flarum\Http\RequestUtil;
+use Flarum\Http\SessionAccessToken;
+use Flarum\Http\SessionAuthenticator;
+use Flarum\User\Exception\PermissionDeniedException;
+use Flarum\User\User;
+use FoF\Impersonate\Events\ImpersonationEnded;
+use FoF\Impersonate\Impersonation;
+use Illuminate\Contracts\Session\Session;
+use Illuminate\Events\Dispatcher;
+use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class ReturnController implements RequestHandlerInterface
+{
+    public function __construct(
+        protected SessionAuthenticator $authenticator,
+        protected Rememberer $rememberer,
+        protected Dispatcher $bus
+    ) {
+    }
+
+    /**
+     * Switch the session back to the user who started impersonating.
+     *
+     * Deliberately does not re-check the fofCanImpersonate policy: returning to
+     * your own account must always work, even if the permission was revoked
+     * mid-session. The marker was written server-side at a moment permission
+     * was verified.
+     *
+     * @throws PermissionDeniedException
+     */
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $actor = RequestUtil::getActor($request);
+
+        /**
+         * @var Session|null $session
+         */
+        $session = $request->getAttribute('session');
+
+        $originalUserId = $session?->get(Impersonation::ORIGINAL_USER_SESSION_KEY);
+
+        // Require a live impersonated session: a guest whose session token has
+        // expired must not be able to enter the original account without credentials.
+        if ($actor->isGuest() || !$originalUserId) {
+            throw new PermissionDeniedException();
+        }
+
+        // Only the account the impersonator actually switched to may return. Core's
+        // POST /login preserves session attributes, so after a credentialed login into
+        // a different account the markers are stale — clear them instead of honoring them.
+        if ($actor->id !== (int) $session->get(Impersonation::IMPERSONATED_USER_SESSION_KEY)) {
+            $session->forget(Impersonation::ORIGINAL_USER_SESSION_KEY);
+            $session->forget(Impersonation::IMPERSONATED_USER_SESSION_KEY);
+
+            throw new PermissionDeniedException();
+        }
+
+        /**
+         * @var User|null $originalUser
+         */
+        $originalUser = User::query()->find($originalUserId);
+
+        if (!$originalUser) {
+            // The original account no longer exists; end the session entirely.
+            $this->authenticator->logOut($session);
+
+            return $this->success();
+        }
+
+        // logIn() replaces the session's token without deleting it, so remove the
+        // impersonation token explicitly before switching back.
+        AccessToken::findValid($session->get('access_token'))?->delete();
+
+        // Restore an equivalent session to the one impersonation replaced: the
+        // original remember token was deleted then, so mint a fresh one now.
+        $token = $session->get(Impersonation::ORIGINAL_REMEMBER_SESSION_KEY)
+            ? RememberAccessToken::generate($originalUser->id)
+            : SessionAccessToken::generate($originalUser->id);
+
+        $this->authenticator->logIn($session, $token);
+
+        // The markers survive logIn()'s session regeneration; clear them explicitly.
+        $session->forget(Impersonation::ORIGINAL_USER_SESSION_KEY);
+        $session->forget(Impersonation::IMPERSONATED_USER_SESSION_KEY);
+        $session->forget(Impersonation::ORIGINAL_REMEMBER_SESSION_KEY);
+
+        $this->bus->dispatch(new ImpersonationEnded($actor, $originalUser));
+
+        $response = $this->success();
+
+        if ($token instanceof RememberAccessToken) {
+            $response = $this->rememberer->remember($response, $token);
+        }
+
+        return $response;
+    }
+
+    protected function success(): ResponseInterface
+    {
+        return new JsonResponse([
+            'data' => [
+                'type'       => 'impersonate',
+                'attributes' => [
+                    'success' => true,
+                ],
+            ],
+        ]);
+    }
+}

--- a/src/Events/ImpersonationEnded.php
+++ b/src/Events/ImpersonationEnded.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of fof/impersonate.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Impersonate\Events;
+
+use Flarum\User\User;
+
+class ImpersonationEnded
+{
+    /**
+     * @param User $user         The account that was being impersonated.
+     * @param User $originalUser The account that was returned to.
+     */
+    public function __construct(public User $user, public User $originalUser)
+    {
+    }
+}

--- a/src/ImpersonateServiceProvider.php
+++ b/src/ImpersonateServiceProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of fof/impersonate.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Impersonate;
+
+use Flarum\Foundation\AbstractServiceProvider;
+use Flarum\User\User;
+
+class ImpersonateServiceProvider extends AbstractServiceProvider
+{
+    public function boot(): void
+    {
+        // Impersonation must leave no activity trace on the target account: freeze
+        // last_seen_at (which also drives the "online" indicator) whenever a save
+        // during an impersonated request would bump it. Request-scoped, so the real
+        // user's own devices still update it normally.
+        User::saving(function (User $user) {
+            if (Impersonation::$impersonatedUserId === $user->id && $user->isDirty('last_seen_at')) {
+                $user->last_seen_at = $user->getOriginal('last_seen_at');
+            }
+        });
+    }
+}

--- a/src/Impersonation.php
+++ b/src/Impersonation.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of fof/impersonate.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Impersonate;
+
+final class Impersonation
+{
+    /**
+     * Session key holding the id of the user who started impersonating.
+     *
+     * Lives in the session because logIn() regenerates the session but keeps its
+     * attributes, while a real logout invalidates (flushes) them — so the marker
+     * survives impersonation and is destroyed by logout without extra handling.
+     */
+    public const ORIGINAL_USER_SESSION_KEY = 'fof_impersonate_original_user_id';
+
+    /**
+     * Session key holding the id of the user currently being impersonated.
+     *
+     * Returning is only honored while the session's actor matches this id: core's
+     * POST /login preserves session attributes, so without this check a credentialed
+     * login into an unrelated account mid-impersonation would inherit the return path.
+     */
+    public const IMPERSONATED_USER_SESSION_KEY = 'fof_impersonate_impersonated_user_id';
+
+    /**
+     * Session key remembering whether the original user was logged in with a
+     * remember token, so returning can restore an equivalent session.
+     */
+    public const ORIGINAL_REMEMBER_SESSION_KEY = 'fof_impersonate_original_remember';
+
+    /**
+     * Id of the user being impersonated by the current request's session, if any.
+     *
+     * Request-scoped: set by the DetectImpersonation middleware before
+     * authentication runs, so the last_seen_at guard can tell impersonated
+     * activity apart from the user's own.
+     */
+    public static ?int $impersonatedUserId = null;
+}

--- a/src/Middleware/DetectImpersonation.php
+++ b/src/Middleware/DetectImpersonation.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of fof/impersonate.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Impersonate\Middleware;
+
+use FoF\Impersonate\Impersonation;
+use Illuminate\Contracts\Session\Session;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface as Handler;
+
+/**
+ * Records whether the current request's session is impersonating, before
+ * AuthenticateWithSession runs and updates the actor's last_seen_at.
+ */
+class DetectImpersonation implements MiddlewareInterface
+{
+    public function process(Request $request, Handler $handler): Response
+    {
+        /**
+         * @var Session|null $session
+         */
+        $session = $request->getAttribute('session');
+
+        $impersonatedUserId = $session?->get(Impersonation::IMPERSONATED_USER_SESSION_KEY);
+
+        Impersonation::$impersonatedUserId = $impersonatedUserId ? (int) $impersonatedUserId : null;
+
+        try {
+            return $handler->handle($request);
+        } finally {
+            Impersonation::$impersonatedUserId = null;
+        }
+    }
+}

--- a/tests/integration/LastSeenTest.php
+++ b/tests/integration/LastSeenTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of fof/impersonate.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Impersonate\Tests\integration;
+
+use Flarum\Extend\Csrf;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ResponseInterface;
+
+class LastSeenTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-impersonate');
+
+        $this->extend(
+            (new Csrf())->exemptRoute('login'),
+            (new Csrf())->exemptRoute('fof.impersonate.api.login'),
+            (new Csrf())->exemptRoute('fof.impersonate.api.return')
+        );
+
+        $this->prepareDatabase([
+            User::class => [
+                [
+                    'id'       => 3,
+                    'username' => 'user3',
+                    'email'    => 'user3@example.com',
+                ],
+            ],
+        ]);
+    }
+
+    protected function loginAsAdmin(): ResponseInterface
+    {
+        return $this->send($this->request('POST', '/login', [
+            'json' => [
+                'identification' => 'admin',
+                'password'       => 'password',
+            ],
+        ]));
+    }
+
+    protected function impersonate(ResponseInterface $cookiesFrom, int $userId): ResponseInterface
+    {
+        return $this->send($this->request('POST', '/api/impersonate', [
+            'cookiesFrom' => $cookiesFrom,
+            'json'        => [
+                'data' => [
+                    'attributes' => [
+                        'userId' => $userId,
+                        'reason' => 'testing',
+                    ],
+                ],
+            ],
+        ]));
+    }
+
+    protected function lastSeenAt(int $userId): ?string
+    {
+        return User::query()->find($userId)->getRawOriginal('last_seen_at');
+    }
+
+    #[Test]
+    public function browsing_while_impersonated_does_not_update_last_seen()
+    {
+        $adminSession = $this->loginAsAdmin();
+
+        $impersonated = $this->impersonate($adminSession, 3);
+        $this->assertEquals(200, $impersonated->getStatusCode());
+
+        // Browse the forum as the impersonated user.
+        $response = $this->send($this->request('GET', '/api', [
+            'cookiesFrom' => $impersonated,
+        ]));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $this->assertNull($this->lastSeenAt(3));
+    }
+
+    #[Test]
+    public function browsing_normally_updates_last_seen()
+    {
+        // Sanity check that the guard doesn't suppress regular activity: the
+        // admin's own login session updates their last_seen_at.
+        $adminSession = $this->loginAsAdmin();
+
+        $response = $this->send($this->request('GET', '/api', [
+            'cookiesFrom' => $adminSession,
+        ]));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $this->assertNotNull($this->lastSeenAt(1));
+    }
+
+    #[Test]
+    public function browsing_after_returning_updates_last_seen_again()
+    {
+        $adminSession = $this->loginAsAdmin();
+
+        $impersonated = $this->impersonate($adminSession, 3);
+        $this->assertEquals(200, $impersonated->getStatusCode());
+
+        $returned = $this->send($this->request('POST', '/api/impersonate/return', [
+            'cookiesFrom' => $impersonated,
+        ]));
+        $this->assertEquals(200, $returned->getStatusCode());
+
+        $response = $this->send($this->request('GET', '/api', [
+            'cookiesFrom' => $returned,
+        ]));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $this->assertNotNull($this->lastSeenAt(1));
+        $this->assertNull($this->lastSeenAt(3));
+    }
+}

--- a/tests/integration/PermissionsTest.php
+++ b/tests/integration/PermissionsTest.php
@@ -1,0 +1,266 @@
+<?php
+
+/*
+ * This file is part of fof/impersonate.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Impersonate\Tests\integration;
+
+use Flarum\Extend\Csrf;
+use Flarum\Group\Group;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ResponseInterface;
+
+class PermissionsTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    // BCrypt hash for "too-obscure", same as RetrievesAuthorizedUsers::normalUser().
+    protected const PASSWORD_HASH = '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-impersonate');
+
+        $this->extend(
+            (new Csrf())->exemptRoute('login'),
+            (new Csrf())->exemptRoute('fof.impersonate.api.login'),
+            (new Csrf())->exemptRoute('fof.impersonate.api.return')
+        );
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                [
+                    'id'                 => 4,
+                    'username'           => 'moduser',
+                    'email'              => 'moduser@machine.local',
+                    'password'           => self::PASSWORD_HASH,
+                    'is_email_confirmed' => 1,
+                ],
+                [
+                    'id'                 => 5,
+                    'username'           => 'moduser2',
+                    'email'              => 'moduser2@machine.local',
+                    'is_email_confirmed' => 1,
+                ],
+                [
+                    'id'                 => 6,
+                    'username'           => 'admin2',
+                    'email'              => 'admin2@machine.local',
+                    'is_email_confirmed' => 1,
+                ],
+            ],
+            'group_user' => [
+                ['user_id' => 4, 'group_id' => Group::MODERATOR_ID],
+                ['user_id' => 5, 'group_id' => Group::MODERATOR_ID],
+                ['user_id' => 6, 'group_id' => Group::ADMINISTRATOR_ID],
+            ],
+            'group_permission' => [
+                ['permission' => 'fof-impersonate.login', 'group_id' => Group::MODERATOR_ID],
+            ],
+        ]);
+    }
+
+    protected function loginAs(string $identification, string $password): ResponseInterface
+    {
+        return $this->send($this->request('POST', '/login', [
+            'json' => compact('identification', 'password'),
+        ]));
+    }
+
+    protected function impersonate(?ResponseInterface $cookiesFrom, int $userId): ResponseInterface
+    {
+        $options = [
+            'json' => [
+                'data' => [
+                    'attributes' => [
+                        'userId' => $userId,
+                        'reason' => 'testing',
+                    ],
+                ],
+            ],
+        ];
+
+        if ($cookiesFrom) {
+            $options['cookiesFrom'] = $cookiesFrom;
+        }
+
+        return $this->send($this->request('POST', '/api/impersonate', $options));
+    }
+
+    protected function returnToOriginalUser(ResponseInterface $cookiesFrom): ResponseInterface
+    {
+        return $this->send($this->request('POST', '/api/impersonate/return', [
+            'cookiesFrom' => $cookiesFrom,
+        ]));
+    }
+
+    /* -------------------------------------------------------------------------
+     * Moderators (permission granted to the group, no admin short-circuit)
+     * ---------------------------------------------------------------------- */
+
+    #[Test]
+    public function moderator_can_impersonate_normal_user()
+    {
+        $modSession = $this->loginAs('moduser', 'too-obscure');
+
+        $impersonated = $this->impersonate($modSession, 2);
+        $this->assertEquals(200, $impersonated->getStatusCode());
+
+        // The session is now the unprivileged user's: impersonating again fails,
+        // proving the actor really switched.
+        $this->assertEquals(403, $this->impersonate($impersonated, 5)->getStatusCode());
+    }
+
+    #[Test]
+    public function moderator_can_impersonate_another_moderator()
+    {
+        $modSession = $this->loginAs('moduser', 'too-obscure');
+
+        $this->assertEquals(200, $this->impersonate($modSession, 5)->getStatusCode());
+    }
+
+    #[Test]
+    public function moderator_cannot_impersonate_admin()
+    {
+        $modSession = $this->loginAs('moduser', 'too-obscure');
+
+        $this->assertEquals(403, $this->impersonate($modSession, 1)->getStatusCode());
+        $this->assertEquals(403, $this->impersonate($modSession, 6)->getStatusCode());
+    }
+
+    #[Test]
+    public function moderator_cannot_impersonate_self()
+    {
+        $modSession = $this->loginAs('moduser', 'too-obscure');
+
+        $this->assertEquals(403, $this->impersonate($modSession, 4)->getStatusCode());
+    }
+
+    #[Test]
+    public function moderator_can_return_to_own_account()
+    {
+        $modSession = $this->loginAs('moduser', 'too-obscure');
+
+        $impersonated = $this->impersonate($modSession, 2);
+        $this->assertEquals(200, $impersonated->getStatusCode());
+
+        $returned = $this->returnToOriginalUser($impersonated);
+        $this->assertEquals(200, $returned->getStatusCode());
+
+        // Impersonating again succeeds, proving the moderator was restored.
+        $this->assertEquals(200, $this->impersonate($returned, 2)->getStatusCode());
+    }
+
+    /* -------------------------------------------------------------------------
+     * Admins
+     * ---------------------------------------------------------------------- */
+
+    #[Test]
+    public function admin_can_impersonate_moderator()
+    {
+        $adminSession = $this->loginAs('admin', 'password');
+
+        $this->assertEquals(200, $this->impersonate($adminSession, 4)->getStatusCode());
+    }
+
+    #[Test]
+    public function admin_can_impersonate_another_admin()
+    {
+        $adminSession = $this->loginAs('admin', 'password');
+
+        $this->assertEquals(200, $this->impersonate($adminSession, 6)->getStatusCode());
+    }
+
+    #[Test]
+    public function admin_cannot_impersonate_self()
+    {
+        $adminSession = $this->loginAs('admin', 'password');
+
+        // The policy's explicit deny applies even to admins.
+        $this->assertEquals(403, $this->impersonate($adminSession, 1)->getStatusCode());
+    }
+
+    /* -------------------------------------------------------------------------
+     * Users without the permission, guests, and escalation attempts
+     * ---------------------------------------------------------------------- */
+
+    #[Test]
+    public function member_without_permission_cannot_impersonate()
+    {
+        $memberSession = $this->loginAs('normal', 'too-obscure');
+
+        $this->assertEquals(403, $this->impersonate($memberSession, 5)->getStatusCode());
+    }
+
+    #[Test]
+    public function guest_cannot_impersonate()
+    {
+        $this->assertEquals(403, $this->impersonate(null, 2)->getStatusCode());
+    }
+
+    #[Test]
+    public function impersonated_user_cannot_escalate_by_impersonating_others()
+    {
+        $modSession = $this->loginAs('moduser', 'too-obscure');
+
+        // Switch to a user without the permission...
+        $impersonated = $this->impersonate($modSession, 2);
+        $this->assertEquals(200, $impersonated->getStatusCode());
+
+        // ...who must not inherit the moderator's ability to impersonate.
+        $this->assertEquals(403, $this->impersonate($impersonated, 5)->getStatusCode());
+        $this->assertEquals(403, $this->impersonate($impersonated, 1)->getStatusCode());
+    }
+
+    /* -------------------------------------------------------------------------
+     * API attribute visibility
+     * ---------------------------------------------------------------------- */
+
+    #[Test]
+    public function user_resource_exposes_impersonation_ability_to_moderator()
+    {
+        $response = $this->send($this->request('GET', '/api/users/2', [
+            'authenticatedAs' => 4,
+        ]));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $attributes = json_decode($response->getBody()->getContents(), true)['data']['attributes'];
+        $this->assertTrue($attributes['canFoFImpersonate']);
+    }
+
+    #[Test]
+    public function user_resource_hides_impersonation_ability_for_admin_target()
+    {
+        $response = $this->send($this->request('GET', '/api/users/1', [
+            'authenticatedAs' => 4,
+        ]));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $attributes = json_decode($response->getBody()->getContents(), true)['data']['attributes'];
+        $this->assertArrayNotHasKey('canFoFImpersonate', $attributes);
+    }
+
+    #[Test]
+    public function user_resource_hides_impersonation_ability_from_member()
+    {
+        $response = $this->send($this->request('GET', '/api/users/5', [
+            'authenticatedAs' => 2,
+        ]));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $attributes = json_decode($response->getBody()->getContents(), true)['data']['attributes'];
+        $this->assertArrayNotHasKey('canFoFImpersonate', $attributes);
+    }
+}

--- a/tests/integration/RequireReasonTest.php
+++ b/tests/integration/RequireReasonTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of fof/impersonate.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Impersonate\Tests\integration;
+
+use Flarum\Audit\AuditLog;
+use Flarum\Audit\AuditLogger;
+use Flarum\Extend\Csrf;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use FoF\ModeratorNotes\Model\ModeratorNote;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ResponseInterface;
+
+class RequireReasonTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Lifecycle events fired outside the test transaction shouldn't create stray entries.
+        AuditLogger::$testMode = true;
+
+        $this->extend(
+            (new Csrf())->exemptRoute('login'),
+            (new Csrf())->exemptRoute('fof.impersonate.api.login')
+        );
+
+        $this->prepareDatabase([
+            User::class => [
+                [
+                    'id'       => 3,
+                    'username' => 'user3',
+                    'email'    => 'user3@example.com',
+                ],
+            ],
+        ]);
+    }
+
+    protected function impersonate(?string $reason): ResponseInterface
+    {
+        $adminSession = $this->send($this->request('POST', '/login', [
+            'json' => [
+                'identification' => 'admin',
+                'password'       => 'password',
+            ],
+        ]));
+
+        $attributes = ['userId' => 3];
+
+        if ($reason !== null) {
+            $attributes['reason'] = $reason;
+        }
+
+        return $this->send($this->request('POST', '/api/impersonate', [
+            'cookiesFrom' => $adminSession,
+            'json'        => [
+                'data' => ['attributes' => $attributes],
+            ],
+        ]));
+    }
+
+    /* -------------------------------------------------------------------------
+     * Activation via flarum/audit
+     * ---------------------------------------------------------------------- */
+
+    #[Test]
+    public function reason_is_required_when_audit_is_enabled()
+    {
+        $this->extension('flarum-audit', 'fof-impersonate');
+        $this->setting('fof-impersonate.require_reason', '1');
+        $this->prepareDatabase(['audit_log' => []]);
+
+        $this->assertEquals(422, $this->impersonate(null)->getStatusCode());
+        $this->assertEquals(422, $this->impersonate('')->getStatusCode());
+    }
+
+    #[Test]
+    public function reason_is_accepted_and_logged_when_audit_is_enabled()
+    {
+        $this->extension('flarum-audit', 'fof-impersonate');
+        $this->setting('fof-impersonate.require_reason', '1');
+        $this->prepareDatabase(['audit_log' => []]);
+
+        $this->assertEquals(200, $this->impersonate('support ticket #123')->getStatusCode());
+
+        $log = AuditLog::query()->where('action', 'user.impersonated')->first();
+        $this->assertNotNull($log);
+        $this->assertEquals('support ticket #123', $log->payload['reason']);
+    }
+
+    #[Test]
+    public function reason_is_optional_when_audit_is_enabled_but_setting_is_off()
+    {
+        $this->extension('flarum-audit', 'fof-impersonate');
+        $this->prepareDatabase(['audit_log' => []]);
+
+        $this->assertEquals(200, $this->impersonate(null)->getStatusCode());
+    }
+
+    /* -------------------------------------------------------------------------
+     * Activation via fof/moderator-notes
+     * ---------------------------------------------------------------------- */
+
+    #[Test]
+    public function reason_is_required_when_moderator_notes_is_enabled()
+    {
+        $this->extension('fof-moderator-notes', 'fof-impersonate');
+        $this->setting('fof-impersonate.require_reason', '1');
+
+        $this->assertEquals(422, $this->impersonate(null)->getStatusCode());
+        $this->assertEquals(422, $this->impersonate('')->getStatusCode());
+    }
+
+    #[Test]
+    public function reason_is_accepted_and_noted_when_moderator_notes_is_enabled()
+    {
+        $this->extension('fof-moderator-notes', 'fof-impersonate');
+        $this->setting('fof-impersonate.require_reason', '1');
+
+        $this->assertEquals(200, $this->impersonate('support ticket #123')->getStatusCode());
+
+        // moderator-notes listens to our Impersonated event and leaves a note on
+        // both the impersonated user and the actor. (The reason is embedded via
+        // its translations, which don't render in the test environment — the
+        // formatting is moderator-notes' contract, not ours.)
+        $notes = ModeratorNote::query()->orderBy('user_id')->get();
+        $this->assertCount(2, $notes);
+        $this->assertEquals([1, 3], $notes->pluck('user_id')->all());
+        $this->assertEquals([1, 1], $notes->pluck('added_by_user_id')->all());
+    }
+
+    /* -------------------------------------------------------------------------
+     * No recording extension enabled: the requirement is inactive
+     * ---------------------------------------------------------------------- */
+
+    #[Test]
+    public function reason_is_not_required_without_a_recording_extension()
+    {
+        $this->extension('fof-impersonate');
+        $this->setting('fof-impersonate.require_reason', '1');
+
+        $this->assertEquals(200, $this->impersonate(null)->getStatusCode());
+    }
+}

--- a/tests/integration/ReturnTest.php
+++ b/tests/integration/ReturnTest.php
@@ -1,0 +1,231 @@
+<?php
+
+/*
+ * This file is part of fof/impersonate.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Impersonate\Tests\integration;
+
+use Flarum\Audit\AuditLog;
+use Flarum\Audit\AuditLogger;
+use Flarum\Extend\Csrf;
+use Flarum\Group\Group;
+use Flarum\Http\AccessToken;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ResponseInterface;
+
+class ReturnTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Lifecycle events fired outside the test transaction shouldn't create stray entries.
+        AuditLogger::$testMode = true;
+
+        $this->extension('flarum-audit', 'fof-impersonate');
+
+        $this->extend(
+            (new Csrf())->exemptRoute('login'),
+            (new Csrf())->exemptRoute('fof.impersonate.api.login'),
+            (new Csrf())->exemptRoute('fof.impersonate.api.return')
+        );
+
+        $this->prepareDatabase([
+            'audit_log' => [],
+            User::class => [
+                $this->normalUser(),
+                [
+                    'id'       => 3,
+                    'username' => 'user3',
+                    'email'    => 'user3@example.com',
+                ],
+                [
+                    'id'       => 4,
+                    'username' => 'user4',
+                    'email'    => 'user4@example.com',
+                ],
+            ],
+            'group_permission' => [
+                // Lets user3 impersonate in the chained impersonation test.
+                ['permission' => 'fof-impersonate.login', 'group_id' => Group::MEMBER_ID],
+            ],
+        ]);
+    }
+
+    protected function loginAsAdmin(bool $remember = false): ResponseInterface
+    {
+        return $this->send($this->request('POST', '/login', [
+            'json' => [
+                'identification' => 'admin',
+                'password'       => 'password',
+                'remember'       => $remember,
+            ],
+        ]));
+    }
+
+    protected function rememberTokenCount(int $userId): int
+    {
+        return AccessToken::query()->where('user_id', $userId)->where('type', 'session_remember')->count();
+    }
+
+    protected function impersonate(ResponseInterface $cookiesFrom, int $userId): ResponseInterface
+    {
+        return $this->send($this->request('POST', '/api/impersonate', [
+            'cookiesFrom' => $cookiesFrom,
+            'json'        => [
+                'data' => [
+                    'attributes' => [
+                        'userId' => $userId,
+                        'reason' => 'testing',
+                    ],
+                ],
+            ],
+        ]));
+    }
+
+    protected function returnToOriginalUser(?ResponseInterface $cookiesFrom = null): ResponseInterface
+    {
+        $options = $cookiesFrom ? ['cookiesFrom' => $cookiesFrom] : [];
+
+        return $this->send($this->request('POST', '/api/impersonate/return', $options));
+    }
+
+    #[Test]
+    public function return_restores_original_user()
+    {
+        $adminSession = $this->loginAsAdmin();
+
+        $impersonated = $this->impersonate($adminSession, 3);
+        $this->assertEquals(200, $impersonated->getStatusCode());
+
+        $returned = $this->returnToOriginalUser($impersonated);
+        $this->assertEquals(200, $returned->getStatusCode());
+
+        // The impersonated user's session token must be gone.
+        $this->assertEquals(0, AccessToken::query()->where('user_id', 3)->count());
+
+        $log = AuditLog::query()->where('action', 'user.impersonation_ended')->first();
+        $this->assertNotNull($log);
+        $this->assertEquals(3, $log->actor_id);
+        $this->assertEquals(['user_id' => 1], $log->payload);
+
+        // A session-only login stays session-only: no remember token is minted.
+        $this->assertEquals(0, $this->rememberTokenCount(1));
+
+        // The session is the admin's again: impersonating requires the permission,
+        // so a successful second impersonation proves the actor was restored.
+        $this->assertEquals(200, $this->impersonate($returned, 3)->getStatusCode());
+    }
+
+    #[Test]
+    public function return_restores_remember_session()
+    {
+        $adminSession = $this->loginAsAdmin(remember: true);
+        $this->assertEquals(1, $this->rememberTokenCount(1));
+
+        $impersonated = $this->impersonate($adminSession, 3);
+        $this->assertEquals(200, $impersonated->getStatusCode());
+
+        // Impersonating replaces the remember login: the token is deleted, not orphaned.
+        $this->assertEquals(0, $this->rememberTokenCount(1));
+
+        $returned = $this->returnToOriginalUser($impersonated);
+        $this->assertEquals(200, $returned->getStatusCode());
+
+        // Returning mints a fresh remember token and sets its cookie.
+        $this->assertEquals(1, $this->rememberTokenCount(1));
+
+        $rememberToken = AccessToken::query()->where('user_id', 1)->where('type', 'session_remember')->first();
+        $this->assertStringContainsString($rememberToken->token, implode(';', $returned->getHeader('Set-Cookie')));
+    }
+
+    #[Test]
+    public function return_without_impersonating_is_denied()
+    {
+        $adminSession = $this->loginAsAdmin();
+
+        $response = $this->returnToOriginalUser($adminSession);
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function return_as_guest_is_denied()
+    {
+        $response = $this->returnToOriginalUser();
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function chained_impersonation_returns_to_first_user()
+    {
+        $adminSession = $this->loginAsAdmin();
+
+        $asUser3 = $this->impersonate($adminSession, 3);
+        $this->assertEquals(200, $asUser3->getStatusCode());
+
+        $asUser4 = $this->impersonate($asUser3, 4);
+        $this->assertEquals(200, $asUser4->getStatusCode());
+
+        $returned = $this->returnToOriginalUser($asUser4);
+        $this->assertEquals(200, $returned->getStatusCode());
+
+        // Returning skips the middle of the chain and restores the admin.
+        $log = AuditLog::query()->where('action', 'user.impersonation_ended')->first();
+        $this->assertNotNull($log);
+        $this->assertEquals(4, $log->actor_id);
+        $this->assertEquals(['user_id' => 1], $log->payload);
+    }
+
+    #[Test]
+    public function return_after_logging_into_another_account_is_denied()
+    {
+        $adminSession = $this->loginAsAdmin();
+
+        $impersonated = $this->impersonate($adminSession, 3);
+        $this->assertEquals(200, $impersonated->getStatusCode());
+
+        // Log into an unrelated account within the impersonating session. Core's
+        // login preserves session attributes, so the markers survive this and must
+        // not hand this account the admin's return path.
+        $loggedIn = $this->send($this->request('POST', '/login', [
+            'cookiesFrom' => $impersonated,
+            'json'        => [
+                'identification' => 'normal',
+                'password'       => 'too-obscure',
+            ],
+        ]));
+        $this->assertEquals(200, $loggedIn->getStatusCode());
+
+        $this->assertEquals(403, $this->returnToOriginalUser($loggedIn)->getStatusCode());
+    }
+
+    #[Test]
+    public function return_logs_out_when_original_user_is_gone()
+    {
+        $adminSession = $this->loginAsAdmin();
+
+        $impersonated = $this->impersonate($adminSession, 3);
+        $this->assertEquals(200, $impersonated->getStatusCode());
+
+        User::query()->where('id', 1)->delete();
+
+        $returned = $this->returnToOriginalUser($impersonated);
+        $this->assertEquals(200, $returned->getStatusCode());
+
+        // The session was ended entirely, so a second return finds a guest.
+        $this->assertEquals(403, $this->returnToOriginalUser($returned)->getStatusCode());
+    }
+}


### PR DESCRIPTION
Closes the long-standing gap where impersonation was one-way: impersonating replaced the session with the target user's, and getting back to your own account meant logging out and in again.

## Return flow

- New `POST /api/impersonate/return` endpoint switches the session back to the account that started impersonating.
- The original user id is kept in the session, which survives `logIn()`'s regeneration but is flushed by logout and by session expiry — so the return path dies exactly when the session does.
- While impersonating, a notice (same area as the email confirmation alert) and a session-dropdown entry show **Return to {username}**.
- Remember sessions are restored: if the impersonator logged in with "remember me", returning mints a fresh remember token. The pre-impersonation token is now deleted rather than orphaned (previously the remember token stayed valid in the DB for up to 5 years with only its cookie expired).

## Security

- Returning requires a live, non-guest session and is bound to the exact account that was impersonated: logging into a different account mid-impersonation (core's `POST /login` preserves session attributes) invalidates the return path instead of inheriting it.
- Chained impersonation (A → B → C) returns to the first account; an impersonated session never inherits the impersonator's permission to impersonate.
- The impersonated session still never carries a remember cookie.

## No activity traces

Browsing as an impersonated user no longer updates the target's `last_seen_at`, so they are never shown as online because of the impersonator's activity. Request-scoped (middleware + `User::saving` guard), so the real user's own devices are unaffected.

## Reason requirement

- The *require a reason* setting now also activates with `flarum/audit` enabled (previously only `fof/moderator-notes`), since the audit log records the reason. Modal, admin settings visibility and validation all follow, and the setting gained help text.
- Extension detection in JS switched from `app.initializers.has()` to `'…' in flarum.extensions`.

## Audit integration

- New `ImpersonationEnded` event, logged as `user.impersonation_ended` when flarum/audit is enabled.

## Tests

25 new integration tests (`ReturnTest`, `PermissionsTest`, `LastSeenTest`, `RequireReasonTest`), including a full permission matrix exercised as a moderator (no admin short-circuit): moderators can impersonate users and other moderators but not admins or themselves, guests/members without the permission are denied, and escalation via an impersonated session is blocked. `fof/moderator-notes` (2.0.0-beta.4) added to require-dev to cover the notes activation path.